### PR TITLE
add optinoal padding for optionID

### DIFF
--- a/menu.go
+++ b/menu.go
@@ -49,6 +49,7 @@ type Menu struct {
 	defIcon        string
 	isYN           bool
 	ynDef          DefaultYN
+	padOptionID    bool
 }
 
 //NewMenu creates a menu with a wlog.UI as the writer.
@@ -223,12 +224,17 @@ func (m *Menu) callAppropriateNoOptions() (err error) {
 //hide options when this is a yes or no
 func (m *Menu) print() {
 	if !m.isYN {
+		outputFormat := "%d) %s%s"
+		if m.padOptionID {
+			padding := len(strconv.Itoa(len(m.options)))
+			outputFormat = "%" + strconv.Itoa(padding) + "d) %s%s"
+		}
 		for _, opt := range m.options {
 			icon := m.defIcon
 			if !opt.isDefault {
 				icon = ""
 			}
-			m.ui.Output(fmt.Sprintf("%d) %s%s", opt.ID, icon, opt.Text))
+			m.ui.Output(fmt.Sprintf(outputFormat, opt.ID, icon, opt.Text))
 		}
 	} else {
 		//TODO Allow user to specify what to use as value for YN options

--- a/menu.go
+++ b/menu.go
@@ -86,6 +86,11 @@ func (m *Menu) AddColor(optionColor, questionColor, responseColor, errorColor wl
 	}
 }
 
+// PadOptionID will pad the option IDs when printing, so they all right-align.
+func (m *Menu) PadOptionID() {
+	m.padOptionID = true
+}
+
 //ClearOnMenuRun will clear the screen when a menu is ran.
 //This is checked when LoopOnInvalid is activated.
 //Meaning if an error occurred then it will clear the screen before asking again.

--- a/menu_test.go
+++ b/menu_test.go
@@ -672,6 +672,30 @@ func TestYesNo(t *testing.T) {
 	}
 }
 
+func TestIDPadding(t *testing.T) {
+	stdOut := initTest()
+	reader := strings.NewReader("2")
+	menu := NewMenu("Choose a fruit")
+	menu.ChangeReaderWriter(reader, stdOut, stdOut)
+	menu.PadOptionID()
+	menu.Option("Apple", "", false, nil)
+	menu.Option("Banana", "", false, nil)
+	menu.Option("Cherry", "", false, nil)
+	menu.Option("Dragon Fruit", "", false, nil)
+	menu.Option("Elderberry", "", false, nil)
+	menu.Option("Fig", "", false, nil)
+	menu.Option("Grapes", "", false, nil)
+	menu.Option("Honeydew Melon", "", false, nil)
+	menu.Option("Indian Prune", "", false, nil)
+	menu.Option("Jackfruit", "", false, nil)
+	menu.Option("Kiwi", "", false, nil)
+	_ = menu.Run()
+
+	lines := strings.Split(stdOut.String(), "\n")
+	assert.Equal(t, " 1) Apple", lines[0])
+	assert.Equal(t, "11) Kiwi", lines[10])
+}
+
 func TestTrim(t *testing.T) {
 	for _, c := range trimCases {
 		stdOut := initTest()


### PR DESCRIPTION
add the ability to pad the ID of the options so the printed text is aligned.

#### before

```
9) worker1 - 1.2.3.4
10) worker2 - 5.6.7.8
```

#### after


```
 9) worker1 - 1.2.3.4
10) worker2 - 5.6.7.8
```